### PR TITLE
Disabling obs-browser plugin

### DIFF
--- a/infra/docker/obs/Dockerfile
+++ b/infra/docker/obs/Dockerfile
@@ -101,7 +101,7 @@ ENV VNC_PASSWD=123456
 
 WORKDIR /tmp
 
-ENV OBS_VERSION=26.0.2
+ENV OBS_VERSION=26.1.2
 
 # install obs and the obs-browser plugin
 #TODO: re-enable browser plugin

--- a/infra/docker/obs/Dockerfile
+++ b/infra/docker/obs/Dockerfile
@@ -101,8 +101,10 @@ ENV VNC_PASSWD=123456
 
 WORKDIR /tmp
 
+ENV OBS_VERSION=26.1.2
+
 # install obs and the obs-browser plugin
-RUN git clone https://github.com/obsproject/obs-studio \
+RUN git clone --depth 1 --branch $OBS_VERSION https://github.com/obsproject/obs-studio \
   && cd obs-studio \
   && wget https://cdn-fastly.obsproject.com/downloads/cef_binary_3770_linux64.tar.bz2 \
   && tar xjf cef_binary_3770_linux64.tar.bz2 \

--- a/infra/docker/obs/Dockerfile
+++ b/infra/docker/obs/Dockerfile
@@ -104,15 +104,16 @@ WORKDIR /tmp
 ENV OBS_VERSION=26.0.2
 
 # install obs and the obs-browser plugin
+#TODO: re-enable browser plugin
 RUN git clone --depth 1 --branch $OBS_VERSION https://github.com/obsproject/obs-studio \
   && cd obs-studio \
   && wget https://cdn-fastly.obsproject.com/downloads/cef_binary_3770_linux64.tar.bz2 \
   && tar xjf cef_binary_3770_linux64.tar.bz2 \
   && rm cef_binary_3770_linux64.tar.bz2 \
-  && git clone https://github.com/obsproject/obs-browser ./plugins/obs-browser \
+  && git clone --depth 1 https://github.com/obsproject/obs-browser ./plugins/obs-browser \
   && mkdir -p build \
   && cd build \
-  && cmake -DUNIX_STRUCTURE=1 -DBUILD_BROWSER=ON -DCEF_ROOT_DIR="../cef_binary_3770_linux64" .. \
+  && cmake -DUNIX_STRUCTURE=1 -DBUILD_BROWSER=OFF -DCEF_ROOT_DIR="../cef_binary_3770_linux64" .. \
   && make -j2 \
   && make install
   #TODO: possibly add obs-vst?

--- a/infra/docker/obs/Dockerfile
+++ b/infra/docker/obs/Dockerfile
@@ -101,7 +101,7 @@ ENV VNC_PASSWD=123456
 
 WORKDIR /tmp
 
-ENV OBS_VERSION=26.1.2
+ENV OBS_VERSION=26.0.2
 
 # install obs and the obs-browser plugin
 RUN git clone --depth 1 --branch $OBS_VERSION https://github.com/obsproject/obs-studio \


### PR DESCRIPTION
Doing this cause the docker build is failing

I also pinned the OBS version... it's probably best to not use their `master` anyway cause it can introduce failures like this.

https://github.com/obsproject/obs-studio/tags

---
<!-- markdownlint-disable -->
<details>
<summary>Commands and options</summary>
<br />

You can trigger actions by commenting on this PR:
- `/update` will merge `main` into this PR


</details>
