### PR TITLE
Relaxing super-linter rules

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -24,3 +24,5 @@ jobs:
           VALIDATE_DOCKERFILE_HADOLINT: false
           # disabled cause they dont support CRDs rn
           VALIDATE_KUBERNETES_KUBEVAL: false
+          # disabled until we go through and fix the dupe code issues
+          VALIDATE_JSCPD: false

--- a/db/README.md
+++ b/db/README.md
@@ -57,6 +57,7 @@ devenv up seed
 #### Other
 
 Get leaderboard winners
+
 ```sql
 select users.username, scores.value from scoreboards, scores, users where scoreboards.name = 'guess_state_2021_01' and scores.user_id = users.id and scores.scoreboard_id = scoreboards.id ORDER BY scores.value DESC LIMIT 10;
 ```


### PR DESCRIPTION
The latest super-linter added code duplication spotting, which is cool, but we need to fix those issues before bringing this back

https://github.com/kucherenko/jscpd

---
<!-- markdownlint-disable -->
<details>
<summary>Commands and options</summary>
<br />

You can trigger actions by commenting on this PR:
- `/update` will merge `main` into this PR


</details>
