### PR TITLE
fix(server): floor displayed miles at 0.01 on the admin profile popover

### DIFF
--- a/pkg/server/profile.go
+++ b/pkg/server/profile.go
@@ -39,6 +39,16 @@ type userProfile struct {
 	LastSeen     time.Time
 }
 
+// floorDisplayMiles clamps a miles value to a 0.01 minimum for display so a
+// brand-new viewer never renders as "0.0". Display-only — callers must not
+// persist the result.
+func floorDisplayMiles(m float32) float32 {
+	if m < 0.01 {
+		return 0.01
+	}
+	return m
+}
+
 // userProfileHandler serves GET /admin/user/{username}: the HTML fragment the
 // live console pops over when an operator clicks a username. Phase 2 will add
 // timeout/ban actions here (needs the broadcaster token's
@@ -50,8 +60,11 @@ func userProfileHandler(w http.ResponseWriter, r *http.Request) {
 		if u := findUser(r.Context(), username); u.ID != 0 {
 			prof.Found = true
 			prof.IsBot = u.IsBot
-			prof.Miles = u.Miles
-			prof.MonthlyMiles = monthlyMiles(r.Context(), u)
+			// Floor the *displayed* miles at 0.01 so a brand-new viewer never
+			// shows as "0.0", which reads as broken — matching the !miles
+			// floor. Display-only: stored u.Miles is untouched.
+			prof.Miles = floorDisplayMiles(u.Miles)
+			prof.MonthlyMiles = floorDisplayMiles(monthlyMiles(r.Context(), u))
 			prof.FirstSeen = u.DateCreated
 			prof.LastSeen = u.LastSeen
 			prof.Sessions = sessionCount(r.Context(), username)
@@ -70,8 +83,8 @@ var userProfileTmpl = template.Must(template.New("profile").Parse(`<div class="p
   <div class="profile-name">{{.Username}}{{if .IsBot}} <span class="profile-bot">bot</span>{{end}}</div>
   {{- if .Found}}
   <dl class="profile-stats">
-    <dt>miles</dt><dd>{{printf "%.1f" .Miles}}</dd>
-    <dt>this month</dt><dd>{{printf "%.1f" .MonthlyMiles}}</dd>
+    <dt>miles</dt><dd>{{printf "%.2f" .Miles}}</dd>
+    <dt>this month</dt><dd>{{printf "%.2f" .MonthlyMiles}}</dd>
     <dt>sessions</dt><dd>{{.Sessions}}</dd>
     <dt>first seen</dt><dd>{{if .FirstSeen.IsZero}}unknown{{else}}{{.FirstSeen.Format "2006-01-02"}}{{end}}</dd>
     <dt>last seen</dt><dd>{{if .LastSeen.IsZero}}unknown{{else}}{{.LastSeen.Format "2006-01-02 15:04"}}{{end}}</dd>

--- a/pkg/server/profile_test.go
+++ b/pkg/server/profile_test.go
@@ -45,8 +45,8 @@ func TestUserProfileHandler_Found(t *testing.T) {
 	body := renderProfile(t, "danalol")
 	for _, want := range []string{
 		"danalol",
-		"123.0",      // lifetime miles
-		"42.0",       // this month
+		"123.00",     // lifetime miles
+		"42.00",      // this month
 		">87<",       // sessions
 		"2019-05-01", // first seen
 		`href="https://twitch.tv/danalol"`,
@@ -69,6 +69,34 @@ func TestUserProfileHandler_NotFound(t *testing.T) {
 	}
 	if !strings.Contains(body, "ghost") {
 		t.Errorf("empty card should still name the user")
+	}
+}
+
+// TestUserProfileHandler_FloorsZeroMiles covers a brand-new viewer with no
+// accrued miles: the displayed values floor at 0.01 instead of "0.00", which
+// reads as broken. Display-only — the stored value is unchanged.
+func TestUserProfileHandler_FloorsZeroMiles(t *testing.T) {
+	withProfileSeams(t, users.User{ID: 11, Username: "newbie", Miles: 0}, 1, 0)
+	body := renderProfile(t, "newbie")
+	if strings.Contains(body, ">0.00<") {
+		t.Errorf("brand-new viewer should not render 0.00 miles: %q", body)
+	}
+	if !strings.Contains(body, ">0.01<") {
+		t.Errorf("expected floored 0.01 miles, got %q", body)
+	}
+}
+
+func TestFloorDisplayMiles(t *testing.T) {
+	cases := []struct{ in, want float32 }{
+		{0, 0.01},
+		{0.004, 0.01},
+		{0.01, 0.01},
+		{5.5, 5.5},
+	}
+	for _, tc := range cases {
+		if got := floorDisplayMiles(tc.in); got != tc.want {
+			t.Errorf("floorDisplayMiles(%v) = %v, want %v", tc.in, got, tc.want)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Floor both displayed miles values (lifetime + this-month) at `0.01` on the click-username admin profile popover, and render them at two decimals so the floor is actually visible (the card previously used `%.1f`, which would still print `0.0`). Matches the `!miles` floor from #796. Display-only — stored `users.miles` is unchanged.
- **Onscreens left intentionally untouched:** the only onscreens miles surface is `ShowLeaderboard` (top-N by `value DESC`), so a brand-new 0.00 viewer never appears there. There's no per-user onscreen miles render that could show `0.00`, so adding a floor there would be dead code. Flagging in case you had a specific onscreen in mind.

## Test plan
- [x] `go test ./pkg/server/` — new `TestUserProfileHandler_FloorsZeroMiles` + `TestFloorDisplayMiles`; updated the existing found-user test for the 2-decimal format
- [ ] Dana confirms a brand-new viewer shows `0.01` (not `0.00`) on the profile popover

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>