### PR TITLE
chore(cdk8s): drop unused eso.secret_store() builder

### DIFF
--- a/cdk8s/adanalife_k8s/eso.py
+++ b/cdk8s/adanalife_k8s/eso.py
@@ -13,11 +13,6 @@ covered here:
   3. bare `remoteRef` — one parameter → one Secret key (obs stream-key).
      `data=[ESData(secret_key, key)]`.
 
-SecretStore stays a `cdk8s.ApiObject`: its CRD bundles every ESO provider and one
-(`keepersecurity.getByTitleFallback`) trips jsii's getXxx-name check, so the CRD
-can't be imported. We only use the AWS provider and emit one SecretStore, so the
-untyped path costs little — see cdk8s.yaml's import note.
-
 The keybase-bootstrapped `eso-aws-credentials` Secret lives outside cdk8s —
 cdk8s never creates it; the SecretStore just references it by name.
 """
@@ -26,7 +21,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-import cdk8s
 from constructs import Construct
 
 import imports.io.external_secrets as esx
@@ -55,49 +49,6 @@ class ESData:
     secret_key: str  # key in the materialized Secret
     key: str  # SSM parameter path
     property: str | None = None  # JSON property within the value (pattern 2)
-
-
-def secret_store(
-    scope: Construct, id: str = "secret-store", *, namespace: str | None = None
-):
-    """Per-namespace `aws-secretsmanager` SecretStore. Byte-identical across
-    envs (the in-namespace eso-aws-credentials routes to the right account)."""
-    store = cdk8s.ApiObject(
-        scope,
-        id,
-        api_version="external-secrets.io/v1",
-        kind="SecretStore",
-        metadata={
-            "name": "aws-secretsmanager",
-            **({"namespace": namespace} if namespace else {}),
-        },
-    )
-    store.add_json_patch(
-        cdk8s.JsonPatch.add(
-            "/spec",
-            {
-                "provider": {
-                    "aws": {
-                        "service": "SecretsManager",
-                        "region": "us-east-1",
-                        "auth": {
-                            "secretRef": {
-                                "accessKeyIDSecretRef": {
-                                    "name": "eso-aws-credentials",
-                                    "key": "AWS_ACCESS_KEY_ID",
-                                },
-                                "secretAccessKeySecretRef": {
-                                    "name": "eso-aws-credentials",
-                                    "key": "AWS_SECRET_ACCESS_KEY",
-                                },
-                            }
-                        },
-                    }
-                },
-            },
-        )
-    )
-    return store
 
 
 def external_secret(


### PR DESCRIPTION
## Summary
- Delete `secret_store()` from `cdk8s/adanalife_k8s/eso.py`. It built a `SecretStore` named `aws-secretsmanager` on the AWS **SecretsManager** provider, but nothing ever called it and no `SecretStore` object appears in any synthed manifest. Secrets come from SSM Parameter Store via infra's `aws-parameterstore` store, which every tripbot `ExternalSecret` references — so the builder was both dead and pointed at the wrong backend.
- Drop the module-docstring paragraph justifying why `SecretStore` stayed an untyped `cdk8s.ApiObject`; that rationale existed only for this function.
- Drop the now-unused `import cdk8s`.

Synth-neutral — `cdk8s/dist/` is byte-identical.

## Test plan
- [x] `grep` confirms no caller (the only other `secret_store` hits are the unrelated `secret_store_ref` field) and no top-level `kind: SecretStore` in `cdk8s/dist/`
- [x] `task cdk8s:verify` — re-synth leaves `cdk8s/dist/` unchanged (`git status --short -- dist/` empty), 65 synth-time checks pass
- [x] `pre-commit run --all-files`
- [ ] Confirm the `skip-changelog` label is right for this (pure dead-code removal, no user-facing change)