### PR TITLE
test(chatbot): pin the tip rotation's starting index in test Apps

### DIFF
--- a/pkg/chatbot/commands_test.go
+++ b/pkg/chatbot/commands_test.go
@@ -81,6 +81,14 @@ func newTestApp(vid video.Video) *App {
 		Events:      noopEvents{},
 	}
 	a.indexCommands() // build the registry, same as New() does in production
+	// indexCommands starts the tip rotation at a random index so every restart
+	// doesn't lead with the same line. That draw comes off the global rand, so
+	// a test that reads the rotation sees a different starting point depending
+	// on how much randomness the tests before it consumed — it passes alone and
+	// fails in the full run. Tests that care about the rotation set their own
+	// messages; pinning the index here keeps the ones that don't from
+	// inheriting a coin flip.
+	a.helpIndex = 0
 	return a
 }
 
@@ -88,6 +96,19 @@ func newTestApp(vid video.Video) *App {
 // the registry-inspection and findCommand-routing tests (read-only — they
 // inspect command definitions / routing, never dispatch).
 var builtTestApp = newTestApp(video.Video{})
+
+// A test App's tip rotation starts at a fixed index. In production
+// indexCommands draws it off the global rand so every restart leads with a
+// different tip, which makes anything reading the rotation depend on how much
+// randomness ran before it — the shape that passes alone and fails in the full
+// run.
+func TestNewTestApp_TipRotationStartsDeterministically(t *testing.T) {
+	for range 5 {
+		if got := newTestApp(video.Video{}).helpIndex; got != 0 {
+			t.Fatalf("helpIndex = %d, want 0 — the rotation must not start on a coin flip", got)
+		}
+	}
+}
 
 // --- App.Chat seam ---
 //
@@ -1443,10 +1464,10 @@ func TestUnBotCmd_NonAdmin_DoesNotCallSetBot(t *testing.T) {
 // posts have to differ and then wrap, or a timer firing all day either says the
 // same thing all day or walks off the end.
 //
-// The rotation is installed rather than taken from the config: what survives
-// enabledHelpMessages depends on which commands this App has, and testConf is
-// shared, so the real set is only as long as the tests running before this one
-// left it.
+// The rotation is installed rather than taken from the config so the assertion
+// reads against a set it controls: enabledHelpMessages filters the config's
+// tips down to the commands this App can dispatch, which is a detail this test
+// has no stake in.
 func TestChatter_AdvancesThroughTheRotation(t *testing.T) {
 	app := newTestApp(video.Video{})
 	rec := &recordingChat{}


### PR DESCRIPTION
Closes the order-dependence item filed after [tripbot#1413](https://github.com/adanalife/tripbot/pull/1413/changes) — but the filed diagnosis was wrong, and the real cause is smaller and easier to kill.

## What the item said

That `pkg/chatbot`'s tests share a mutable package-level `testConf`, that `enabledHelpMessages()` therefore filters the tip set down to whatever the previous tests left, and that by the time the new Chatter test ran the surviving set was one line.

## What's actually true

Measured rather than guessed, per the item's own suggestion to start with `-shuffle=on`:

- **Nothing mutates `testConf`.** No test assigns to it or to any `.Cfg` field; it's read-only in practice.
- **The surviving tip set is a stable 12**, not one line, and identical for every App. `enabledHelpMessages` filters against `a.singleWordLookup`, which `indexCommands` builds fresh per App — there's no shared registry to leak.
- **`go test ./pkg/chatbot/ -shuffle=N` passes on every seed tried.** If the order dependence were real this is where it would show.

The actual cause is one line in `indexCommands`:

```go
a.helpIndex = rand.Intn(len(a.helpMessages))
```

Deliberate in production — a restart shouldn't always lead with the same tip — but it draws off the **global** rand, so a test App's starting index depends on how much randomness the suite consumed before it. Probing three Apps in one run gives `helpIndex` 3, 11, 1; the next run gives 8, 0, 2. That is exactly "passes alone, fails in the full run", and it is not an ordering problem, so `-shuffle` was never going to find it.

## The fix

`newTestApp` pins `helpIndex = 0` after `indexCommands`. Tests that assert on the rotation install their own messages and index anyway (that's the workaround #1413 landed, which is the right shape for that test regardless); this stops every other test from inheriting a coin flip.

A test pins the property so the helper can't quietly regress, and the Chatter test's comment is corrected — it currently explains the wrong mechanism.

Full `./pkg/...` suite green; `pkg/chatbot` green across three shuffle seeds.