### PR TITLE
chore(deps): bump google.golang.org/grpc to v1.83.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -101,6 +101,6 @@ require (
 	golang.org/x/time v0.15.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
-	google.golang.org/grpc v1.82.1 // indirect
+	google.golang.org/grpc v1.83.1 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -231,8 +231,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:q4lMZS6kskjT5HvCPrnnypcDPVJqT/f4nfxmkE7gryY=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa h1:mZHHdPZl0dbGHCflZgAq/Q468DWVFcU2whhB2KAo8fk=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
-google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
+google.golang.org/grpc v1.83.1 h1:HIO0+BEtBP6soyqvqC8sNUjZ7bTs+0hFQuFF+RAy++Y=
+google.golang.org/grpc v1.83.1/go.mod h1:kDyl6SKsiHKt0uylY5gtn5cEjkrIOhQOGDgIc4JGwzQ=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
## What

`google.golang.org/grpc` v1.82.1 → v1.83.1 (indirect). Two-line diff in `go.mod` + `go.sum`.

## Why

Open Dependabot alert, **high** severity: *gRPC-Go: Heap Memory Exhaustion (OOM) via HTTP/2 DATA Frame Fragmentation*. Vulnerable `<= 1.83.0`, patched in `1.83.1`.

Dependabot would normally have raised this itself. It can't: the daily `Dependabot Updates` run aborts with `dependency_file_not_found: No files found in /v1`, because 39 of the repo's 40 open alerts are `rubygems` alerts against `v1/Gemfile.lock` — a path deleted in **March 2020**. That path comes from the job definition rather than `.github/dependabot.yml`, so it can't be fixed by editing that file; the alerts need dismissing as `no_longer_used`. Tracked separately.

## Verification

- `go build ./...` clean
- `go vet ./...` clean
- `go test ./...` — full suite passes
- `govulncheck` no longer lists grpc among affected modules

Note that CI's `govulncheck` was already green before this change — it scans with `stable` (go1.27.0) rather than the toolchain this repo pins, so it was never going to catch this. That blind spot is its own PR.