### PR TITLE
fix(ci): make govulncheck scan the pinned Go version, and bump to 1.26.8

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -24,4 +24,12 @@ jobs:
       # duplicate-Authorization 400 on fetch).
       - uses: golang/govulncheck-action@v1
         with:
+          # go-version-input defaults to 'stable' and the action hands both it
+          # and go-version-file to setup-go, which prefers go-version. Left at
+          # the default, go-version-file is dead and the scan runs on whatever
+          # is newest -- so every stdlib fix between our pin and current stable
+          # reads as already-fixed. Blanking it restores go.mod as the source
+          # of truth, which is the toolchain the binaries are actually built
+          # with.
+          go-version-input: ''
           go-version-file: go.mod

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-go 1.26.8
+go 1.26.7
 # Match golangci_lint_version in .github/workflows/linting.yml — move both together.
 golangci-lint 2.12.1

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-go 1.26.5
+go 1.26.8
 # Match golangci_lint_version in .github/workflows/linting.yml — move both together.
 golangci-lint 2.12.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/adanalife/tripbot
 
-go 1.26.8
+go 1.26.7
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/adanalife/tripbot
 
-go 1.26.5
+go 1.26.8
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2


### PR DESCRIPTION
## The gate was blind, and it was hiding seven reachable vulnerabilities

`govulncheck` has been green on `main` while tripbot's code was affected by **seven standard-library vulnerabilities**. Both halves are fixed here.

### Why the gate couldn't see them

`golang/govulncheck-action` hands *both* `go-version-input` (default `'stable'`) and `go-version-file` to `actions/setup-go`, which prefers `go-version`. So `go-version-file: go.mod` was inert and the scan ran on **go1.27.0** while the binaries build on the pinned **1.26.5**. The run log says it plainly:

```
Setup go version spec stable
go version go1.27.0 linux/amd64
No vulnerabilities found.
```

Anything fixed between our pin and current stable therefore reads as already-fixed. The blind spot is exactly the size of the toolchain lag, and it grows on its own.

Blanking `go-version-input` restores `go.mod` as the single source of truth — no version duplicated into the workflow, so it can't drift back.

### What it was hiding

Scanning locally on the pinned 1.26.5 — seven reachable, all patched in **1.26.6**:

| ID | Package |
|---|---|
| GO-2026-6218 | `net/url` — quadratic complexity in `resolvePath` |
| GO-2026-6091 | `html/template` — Javascript regexp context tracking |
| GO-2026-6090 | `crypto/tls` — post-handshake message limits |
| GO-2026-6089 | `net/http` — `ReadHeaderTimeout` on unencrypted HTTP/2 check |
| GO-2026-6088 | `encoding/xml` — recursion depth guard |
| GO-2026-5972 | `encoding/asn1` — recursion depth |
| GO-2026-5026 | `net/http` — ASCII-only Punycode labels via `x/net/idna` |

These aren't theoretical — govulncheck traced each to a real call path, e.g. `pkg/gateway/client.go:181` → `http.Client.Do` and `pkg/natsclient/natsclient.go:82` → `asn1.Unmarshal`.

## Changes

1. **Go 1.26.5 → 1.26.7** (`.tool-versions`, `go.mod`) — latest 1.26 patch, covers all seven. The Dockerfiles float on `golang:1.26-bookworm` and pick it up on their own.
2. **`go-version-input: ''`** in `govulncheck.yml`, with a comment explaining the precedence trap.

## Verification

On 1.26.7, locally:

```
No vulnerabilities found.
Your code is affected by 0 vulnerabilities.
```

`go build ./...` and the full `go test ./...` suite pass. Seven affected → zero.

## Deliberately not doing

**Not bumping to go1.27.x.** A minor-version move is a bigger call than a security patch and it's yours to make — this PR takes the smallest change that clears the advisories. Worth knowing the current stable is `go1.27.1` if you'd rather jump.

Note this PR's `govulncheck` check is now scanning the pinned toolchain for the first time, so a green here means something it didn't mean before.

---

**Retargeted 1.26.8 → 1.26.7.** 1.26.8 broke the image build and the test job: the mirrored `golang:1.26-bookworm` base serves **1.26.7**, and the Dockerfile runs `GOTOOLCHAIN=local`, so `go mod download` refused with `go.mod requires go >= 1.26.8 (running go 1.26.7)`. All seven advisories are fixed in **1.26.6**, so 1.26.7 clears every one of them and `govulncheck` still reports zero affected — the security outcome is identical. Going past 1.26.7 needs the base-image mirror refreshed first, which is its own tracked item.