### PR TITLE
chore(deps): run the cdk8s dependabot entries quarterly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -128,11 +128,11 @@ updates:
       default-days: 7
       semver-major-days: 14
     rebase-strategy: disabled
+    allow:
+      - dependency-type: direct
   # The cdk8s Python layer: the libraries the authoring code imports. The npm
   # entry above covers the CLI half of the same toolchain; without this one the
   # Python half takes no updates at all, security included.
-    allow:
-      - dependency-type: direct
   - package-ecosystem: uv
     directory: cdk8s
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,7 +21,17 @@ updates:
   #                   costs far more CI than it saves; no ruleset here needs
   #                   a branch to be up to date before merging.
   #   schedule        is weekly on Monday 13:00 UTC, so a week's bumps arrive as
-  #                   one batch to review rather than trickling in daily.
+  #                   one batch to review rather than trickling in daily. The
+  #                   two cdk8s entries run quarterly instead: jsii auto-releases
+  #                   both halves of that toolchain on nearly every upstream
+  #                   change -- 33 cdk8s and 46 cdk8s-cli patches in the three
+  #                   months to 2026-09, all inside one minor, since each cuts a
+  #                   minor about once a year. A weekly run turns that steady
+  #                   stream into a weekly PR whatever the cooldown is set to,
+  #                   because there is always a newly-eligible patch; running
+  #                   quarterly is what collapses it to one PR carrying the same
+  #                   end state. Security updates run on their own cadence, so
+  #                   they still arrive within the day.
   #
   # Bumps carry no user-facing change, so they never need a towncrier
   # changelog fragment. Self-apply skip-changelog so the changelog
@@ -100,7 +110,7 @@ updates:
   - package-ecosystem: npm
     directory: cdk8s
     schedule:
-      interval: weekly
+      interval: quarterly
       day: monday
       time: "13:00"
     groups:
@@ -114,19 +124,19 @@ updates:
       - dependencies
       - javascript
       - skip-changelog
-  # The cdk8s Python layer: the libraries the authoring code imports. The npm
-  # entry above covers the CLI half of the same toolchain; without this one the
-  # Python half takes no updates at all, security included.
     cooldown:
       default-days: 7
       semver-major-days: 14
     rebase-strategy: disabled
+  # The cdk8s Python layer: the libraries the authoring code imports. The npm
+  # entry above covers the CLI half of the same toolchain; without this one the
+  # Python half takes no updates at all, security included.
     allow:
       - dependency-type: direct
   - package-ecosystem: uv
     directory: cdk8s
     schedule:
-      interval: weekly
+      interval: quarterly
       day: monday
       time: "13:00"
     groups:


### PR DESCRIPTION
Same change as [infra#1154](https://github.com/adanalife/infra/pull/1154/changes), which carries the full rationale.

## Why

The cdk8s toolchain is auto-released by jsii on nearly every upstream change. Release counts since 2026-06-01:

| package | releases | all inside |
|---|---|---|
| `cdk8s` (PyPI) | 33 | `2.70.x` |
| `cdk8s-cli` (npm) | 46 | `2.207.x` |
| `constructs` (PyPI) | 5 | spans 10.7 → 10.8 |

Every cdk8s and cdk8s-cli release in that window was a patch inside one minor — each project cuts a minor roughly once a year (cdk8s 2.69 → 2.70 was 10 months). So the weekly run produces a bump PR essentially every week, forever, carrying no change the authoring layer can see.

`constructs` is not the churn source and needs no special handling; it rides along in the same `python` group.

## Why not cooldown, why not ignore

- **`cooldown: semver-patch-days`** doesn't help. Cooldown holds each *release* for N days; with a steady ~2–3 patches a week there is always a newly-eligible version at each run, so the PR count is unchanged and the dependency is merely N days staler.
- **`ignore: version-update:semver-patch`** would zero the PRs, but `ignore` conditions apply to security updates too, and with yearly minors it pins the toolchain for about a year.
- **`interval: quarterly`** collapses ~52 PRs/yr to 4, each landing on the newest patch rather than a frozen one. Security updates run on their own cadence, independent of `schedule`, and are exempt from the open-PR limit.

## Scope

The two `cdk8s` directory entries only (npm + uv). gomod, docker, and github-actions keep the weekly Monday batch.

Second commit is unrelated to the schedule: the comment describing the uv entry was sitting inside the npm entry, above that entry's `cooldown` block.