### PR TITLE
chore(comments): make six comments timeless

### DIFF
--- a/pkg/chatbot/commands_test.go
+++ b/pkg/chatbot/commands_test.go
@@ -1562,8 +1562,8 @@ func TestUnBotCmd_Admin_FlipsToFalse(t *testing.T) {
 
 // --- Chatter ---
 
-// The rotating tip set is Chatter's alone now that !help lists commands
-// instead, so this is the only place left that walks the index. Successive
+// The rotating tip set is Chatter's alone — !help lists the command surface
+// instead — so this is the only place that walks the index. Successive
 // posts have to differ and then wrap, or a timer firing all day either says the
 // same thing all day or walks off the end.
 //

--- a/pkg/chatbot/handlers_test.go
+++ b/pkg/chatbot/handlers_test.go
@@ -780,9 +780,9 @@ func TestCheckAccess_RequiresAdmin_Admin(t *testing.T) {
 	}
 }
 
-// Every command that used to gate itself inside its handler now declares it,
-// so a new admin command that forgets the field fails here rather than
-// shipping wide open.
+// Admin commands declare their gate as a registry field rather than checking
+// inside the handler, so a new one that forgets the field fails here rather
+// than shipping wide open.
 func TestRegistry_AdminCommandsDeclareRequiresAdmin(t *testing.T) {
 	want := map[string]bool{
 		"!shutdown": true, "!refreshoverlays": true, "!secretinfo": true,

--- a/pkg/chatbot/registry.go
+++ b/pkg/chatbot/registry.go
@@ -334,8 +334,8 @@ func (a *App) buildRegistry() []Command {
 }
 
 // Platform names for App.Platform. Add a constant here when a new streaming
-// platform (Kick, TikTok, …) comes online; platform-specific commands then
-// reference it via Command.Platforms.
+// platform (Kick, …) comes online; platform-specific commands then reference
+// it via Command.Platforms.
 const (
 	platformTwitch    = "twitch"
 	platformYouTube   = "youtube"
@@ -357,14 +357,13 @@ func (a *App) platform() string {
 }
 
 // v1Commands is the allowlist of triggers a v1-rollout platform instance
-// (YouTube, Facebook, Instagram, TikTok) runs — the "info + playback control" subset, plus the
-// !state/!location info commands.
+// (YouTube, Facebook, Instagram, TikTok) runs — the "info + playback
+// control" subset, plus the !state/!location info commands.
 // Identity/miles commands (!miles, !leaderboard, !guess, …), the Twitch-only
 // !followage, and the admin commands (!middle, !secretinfo, !shutdown, !makebot,
 // !unbot) are excluded: those are per-user identity/score state. !somafm is
 // excluded too — it credits a bed that only Twitch defaults to. Aliases come
-// along with their trigger, so only triggers are listed. See the YouTube
-// provider plan.
+// along with their trigger, so only triggers are listed.
 var v1Commands = map[string]bool{
 	"!version": true, "!uptime": true, "!commands": true,
 	"!gas": true, "!report": true,

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -417,8 +417,8 @@ func CommandRan(ctx context.Context, cfg *c.TripbotConfig, r CommandRun) error {
 
 // preFixSentinel is safely after the 0001-01-01 zero-time the timestamp bug
 // wrote (between the GORM migration #499 and the autoCreateTime fix) but well
-// before any real stream data — the stream started May 2019. Used to exclude
-// the bogus zero-dated rows when reconstructing a user's first-seen date.
+// before any real stream data — the stream started May 2019. Excludes the
+// bogus zero-dated rows when reconstructing a user's first-seen date.
 var preFixSentinel = time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
 
 // EarliestRealEventDate returns the earliest event timestamp for the user that

--- a/pkg/instrumentation/tripbot.go
+++ b/pkg/instrumentation/tripbot.go
@@ -156,10 +156,10 @@ var GatewayConnection = gatewayConnectionGauge{gauge: gatewayUp}
 // disconnect in prod.
 //
 // Counting attempts rather than successes is the load-bearing part. Recovery
-// that keeps failing is the worse outage and the one that used to be invisible:
-// through a 9h41m outage on 2026-08-05 the watchdog attempted a restart every
-// 60s and failed every time, and this counter never moved, so the panel built
-// on it read a flat zero for the whole incident.
+// that keeps failing is the worse outage and the one a success count cannot
+// see: through a 9h41m outage on 2026-08-05 the watchdog attempted a restart
+// every 60s and failed every time, so a success-counted panel reads a flat
+// zero for the whole incident.
 var OBSSilentDisconnectRestarts = obsSilentDisconnectRestartsCounter{counter: obsSilentDisconnectRestarts}
 
 // OBSRecoveryExhausted exposes the watchdog's stood-down state. Set(true,

--- a/pkg/video/video.go
+++ b/pkg/video/video.go
@@ -119,9 +119,9 @@ func (p *Player) GetCurrentlyPlaying(ctx context.Context) {
 // It reads the playhead rather than the clip: video_coords knows which state
 // each moment of a clip is in, so a line crossed mid-clip is recorded at the
 // moment it happens — 48 clips in the corpus cross one — instead of at the
-// next clip switch. A clip with no track answers with its clip-level state,
-// which is what the switch-time comparison used to do; the first observation
-// after boot records nothing, since there is nothing to cross from.
+// next clip switch. A clip with no track answers with its clip-level state;
+// the first observation after boot records nothing, since there is nothing
+// to cross from.
 //
 // sequential says the van drove across the line: either the same clip is still
 // on screen, or the new clip follows the previous one in corpus order


### PR DESCRIPTION
Sixth comment-audit pass over tripbot, scoped to the 198 non-generated files that changed since the fifth (#1376, 2026-08-15) — 132 commits. Comment-only diff: no executable line moves.

**The one that was wrong.** `pkg/chatbot/registry.go`'s platform-constant block said "add a constant here when a new streaming platform (Kick, TikTok, …) comes online" — with `platformTikTok` declared on the very next line and already mapped to `scopeV1` in `platformCommandScope`. A reader deciding whether TikTok is wired got the opposite answer from the comment and the code. Kick alone is the example now, matching how `scopeV1` phrases it.

**The private ref.** `v1Commands` closed with "See the YouTube provider plan." — unreachable from a bare checkout or CI, and the comment already spells out the whole exclusion rationale above it.

**The before/after framing**, four instances, each rewritten to describe the code as it stands:

- `handlers_test.go` — "every command that *used to* gate itself inside its handler *now* declares it"
- `commands_test.go` — the tip rotation is Chatter's "*now that*" `!help` lists commands, "the only place *left*"
- `video.go` — a clip-level state fallback described as "what the switch-time comparison *used to* do"
- `instrumentation/tripbot.go` — the restart counter's "the one that *used to be* invisible". The 9h41m outage it cites is real evidence for counting attempts over successes, so that stays; only the frame changed.

**Also fixed:** `events.go`'s `preFixSentinel` opened with "Used to exclude the bogus zero-dated rows", which scans as past tense sitting next to two sentences of bug history. Now "Excludes".

**Clean on everything else** — zero session/plan jargon, zero other private refs (the `no private-notes paths` pre-commit hook is holding), zero `whitelist`/`blacklist`, and the five in-code `TODO` markers are all already tracked outside the repo, so nothing new to file.

The scoping trick that made this pass cheap: diff against the previous pass's merge date and grep only the files that moved.